### PR TITLE
Inline pdf viewer, leave out unused report sections, few bug fixes

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Huawei_P10_Android_9_SDK28.avd" />
+            <type value="SERIAL_NUMBER" />
+            <value value="R52N81D2DCW" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2021-08-13T17:56:32.819844Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2021-11-06T13:15:03.668866Z" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,13 +3,20 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="app/src/main/res/drawable/ic_baseline_arrow_back_24.xml" value="0.5515625" />
+        <entry key="app/src/main/res/drawable/ic_clear_black_24dp.xml" value="0.334375" />
         <entry key="app/src/main/res/layout/activity_client_list.xml" value="0.2774774774774775" />
+        <entry key="app/src/main/res/layout/activity_configuration.xml" value="0.3182291666666667" />
+        <entry key="app/src/main/res/layout/activity_lump_sum_definition.xml" value="0.3182291666666667" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.2774774774774775" />
         <entry key="app/src/main/res/layout/activity_report_editor.xml" value="0.2927927927927928" />
+        <entry key="app/src/main/res/layout/activity_summary.xml" value="0.3182291666666667" />
         <entry key="app/src/main/res/layout/client_card_layout.xml" value="0.33" />
         <entry key="app/src/main/res/layout/client_select_dialog.xml" value="0.2774774774774775" />
         <entry key="app/src/main/res/layout/client_select_layout.xml" value="0.2774774774774775" />
+        <entry key="app/src/main/res/layout/config_pdf.xml" value="0.3182291666666667" />
         <entry key="app/src/main/res/layout/fragment_bill_editor.xml" value="0.30180180180180183" />
+        <entry key="app/src/main/res/layout/fragment_pdf_preview_dialog.xml" value="0.33" />
         <entry key="app/src/main/res/layout/fragment_work_time_editor.xml" value="0.30180180180180183" />
         <entry key="app/src/main/res/layout/report_filter_layout.xml" value="0.2774774774774775" />
         <entry key="app/src/main/res/layout/work_time_layout.xml" value="0.3396396396396396" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "com.stemaker.arbeitsbericht"
         minSdkVersion 23
         targetSdkVersion 30
-        versionCode 25
-        versionName "v2.14.1"
+        versionCode 26
+        versionName "v2.15.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -96,5 +96,4 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:core-ktx:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.2'
-
 }

--- a/app/src/main/assets/versions.html
+++ b/app/src/main/assets/versions.html
@@ -15,7 +15,8 @@ Die Absturzberichte können auch dauerhaft aktiviert bleiben.
 <ul>
     <li>PDF Vorschau über einen neuen internen viewer. Dieser unterstützt kein zoomen, deshalb kann man weiterhin einen externen PDF viewer in den
         Einstellungen aktivieren falls gewünscht.</li>
-    <li>Unbenutzte Berichtsteile (z.B. keine Einträge unter Material) werden auch bei PDF und XLSX Berichten nicht mehr eingebunden.</li>
+    <li>Unbenutzte Berichtsteile (z.B. keine Einträge unter Material) werden bei PDF und XLSX Berichten nicht mehr eingebunden. Das Verhalten bei ODF ist
+        (noch) unverändert.</li>
     <li>Stabilitätsverbesserungen</li>
 </ul>
 <h2>v2.14.1</h2>

--- a/app/src/main/assets/versions.html
+++ b/app/src/main/assets/versions.html
@@ -11,6 +11,13 @@ Es wurde eine neue Version installiert. Änderungen weiter unten.
 Falls es zu App-Abstürzen kommt, bitte die Absturzberichte in den Einstellungen aktivieren. Das erlaubt mir (hoffentlich) das Problem zu beheben.
 Die Absturzberichte können auch dauerhaft aktiviert bleiben.
 <h1>Änderungen</h1>
+<h2>v2.15.0</h2>
+<ul>
+    <li>PDF Vorschau über einen neuen internen viewer. Dieser unterstützt kein zoomen, deshalb kann man weiterhin einen externen PDF viewer in den
+        Einstellungen aktivieren falls gewünscht.</li>
+    <li>Unbenutzte Berichtsteile (z.B. keine Einträge unter Material) werden auch bei PDF und XLSX Berichten nicht mehr eingebunden.</li>
+    <li>Stabilitätsverbesserungen</li>
+</ul>
 <h2>v2.14.1</h2>
 Fehlerbehebung: Crash wenn die App von Android wegen RAM-Mangel aus dem Speicher gelöscht wird.
 <h2>v2.14.0</h2>

--- a/app/src/main/java/com/stemaker/arbeitsbericht/ConfigurationActivity.kt
+++ b/app/src/main/java/com/stemaker/arbeitsbericht/ConfigurationActivity.kt
@@ -92,6 +92,8 @@ class ConfigurationActivity : AppCompatActivity() {
             findViewById<EditText>(R.id.footer_ftp_path).setText(configuration().footerServerPath)
             findViewById<SwitchMaterial>(R.id.pdf_use_logo).isChecked = configuration().pdfUseLogo
             findViewById<SwitchMaterial>(R.id.pdf_use_footer).isChecked = configuration().pdfUseFooter
+            findViewById<SwitchMaterial>(R.id.pdf_use_internal).isChecked = configuration().useInlinePdfViewer
+
             findViewById<SwitchMaterial>(R.id.xlsx_use_logo).isChecked = configuration().xlsxUseLogo
             findViewById<SwitchMaterial>(R.id.xlsx_use_footer).isChecked = configuration().xlsxUseFooter
             val radioGroup = findViewById<RadioGroup>(R.id.output_type_select_radiogroup)
@@ -299,6 +301,7 @@ class ConfigurationActivity : AppCompatActivity() {
         configuration().fontSize = findViewById<Slider>(R.id.fontsize_slider).value.toInt()
         configuration().pdfUseLogo = findViewById<SwitchMaterial>(R.id.pdf_use_logo).isChecked
         configuration().pdfUseFooter = findViewById<SwitchMaterial>(R.id.pdf_use_footer).isChecked
+        configuration().useInlinePdfViewer = findViewById<SwitchMaterial>(R.id.pdf_use_internal).isChecked
         configuration().xlsxUseLogo = findViewById<SwitchMaterial>(R.id.xlsx_use_logo).isChecked
         configuration().xlsxUseFooter = findViewById<SwitchMaterial>(R.id.xlsx_use_footer).isChecked
         configuration().xlsxLogoWidth = findViewById<Slider>(R.id.xlsx_logo_width_slider).value.toInt()

--- a/app/src/main/java/com/stemaker/arbeitsbericht/data/Configuration.kt
+++ b/app/src/main/java/com/stemaker/arbeitsbericht/data/Configuration.kt
@@ -62,6 +62,7 @@ class ConfigurationStore {
     var scalePhotos: Boolean = false
     var photoResolution: Int = 1024
     var currentClientId: Int = 1
+    var useInlinePdfViewer: Boolean = true
 }
 
 fun configuration(): Configuration {
@@ -328,6 +329,11 @@ object Configuration {
         get(): Int = store.currentClientId
         set(value) {
             store.currentClientId = value}
+
+    var useInlinePdfViewer: Boolean
+        get(): Boolean = store.useInlinePdfViewer
+        set(value) {
+            store.useInlinePdfViewer = value }
 
     private fun encryptPassword(pwd: String): String {
         /* Now we try to store the password in an encrypted way. First we retrieve a key

--- a/app/src/main/java/com/stemaker/arbeitsbericht/editor_fragments/ProjectEditorFragment.kt
+++ b/app/src/main/java/com/stemaker/arbeitsbericht/editor_fragments/ProjectEditorFragment.kt
@@ -41,8 +41,11 @@ class ProjectEditorFragment : ReportEditorSectionFragment() {
         dataBinding.lifecycleOwner = this
 
         GlobalScope.launch(Dispatchers.Main) {
-            dataBinding.projectData = listener!!.getProjectData()
-            dataBinding.reportData = listener!!.getReportData()
+            listener?.also {
+                // There can be a race with onDetach so that the listener is already null
+                dataBinding.projectData = it.getProjectData()
+                dataBinding.reportData = it.getReportData()
+            }
         }
         return root
     }

--- a/app/src/main/java/com/stemaker/arbeitsbericht/helpers/HtmlReport.kt
+++ b/app/src/main/java/com/stemaker/arbeitsbericht/helpers/HtmlReport.kt
@@ -69,23 +69,24 @@ object HtmlReport {
 
 
         // Work times table
-        html += "<h2>Arbeits-/fahrzeiten und Fahrstrecken</h2>" +
-                "<table style=\"border: 2px solid black;border-collapse: collapse;\">" +
+        if(rep.workTimeContainer.items.size > 0) {
+            html += "<h2>Arbeits-/fahrzeiten und Fahrstrecken</h2>" +
+                    "<table style=\"border: 2px solid black;border-collapse: collapse;\">" +
                     "<tr>" +
-                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Datum</th>" +
-                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Mitarbeiter</th>" +
-                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Arbeits-anfang</th>" +
-                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Arbeits-ende</th>" +
-                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Fahrzeit<br>[h:m]</th>" +
-                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Fahr-strecke [km]</th>" +
-                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Pause<br>[h:m]</th>" +
-                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Arbeits-zeit [h:m]</th>" +
-                "</tr>"
+                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Datum</th>" +
+                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Mitarbeiter</th>" +
+                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Arbeits-anfang</th>" +
+                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Arbeits-ende</th>" +
+                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Fahrzeit<br>[h:m]</th>" +
+                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Fahr-strecke [km]</th>" +
+                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Pause<br>[h:m]</th>" +
+                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Arbeits-zeit [h:m]</th>" +
+                    "</tr>"
             rep.workTimeContainer.items.forEach {
-            html += "<tr>" +
+                html += "<tr>" +
                         "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${calendarToDateString(it.date.value)}</td>" +
                         "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\">"
-                for(empl in it.employees)
+                for (empl in it.employees)
                     html += "${empl.value!!}<br>"
                 html += "</td>" +
                         "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.startTime.value} Uhr</td>" +
@@ -94,69 +95,77 @@ object HtmlReport {
                         "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.distance.value}</td>" +
                         "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.pauseDuration.value}</td>" +
                         "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.workDuration.value}</td>" +
-                    "</tr>"
+                        "</tr>"
+            }
+            html += "</table><hr>"
         }
-        html += "</table><hr>"
 
         // Work items table
-        html += "<h2>Durchgeführte Arbeiten</h2>" +
-                "<table style=\"border: 2px solid black;border-collapse: collapse;\">" +
+        if(rep.workItemContainer.items.size > 0) {
+            html += "<h2>Durchgeführte Arbeiten</h2>" +
+                    "<table style=\"border: 2px solid black;border-collapse: collapse;\">" +
                     "<tr>" +
-                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Arbeit</th>" +
+                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Arbeit</th>" +
                     "</tr>"
-        rep.workItemContainer.items.forEach {
-            html += "<tr>" +
+            rep.workItemContainer.items.forEach {
+                html += "<tr>" +
                         "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.item.value}</td>" +
-                    "</tr>"
+                        "</tr>"
+            }
+            html += "</table><hr>"
         }
-        html += "</table><hr>"
 
-        // Lump sums
-        html += "<h2>Pauschalen</h2>" +
-                "<table style=\"border: 2px solid black;border-collapse: collapse;\">" +
+        if(rep.lumpSumContainer.items.size > 0) {
+            // Lump sums
+            html += "<h2>Pauschalen</h2>" +
+                    "<table style=\"border: 2px solid black;border-collapse: collapse;\">" +
                     "<tr>" +
-                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Pauschale</th>" +
-                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Anzahl</th>" +
-                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Bemerkung</th>" +
-                "</tr>"
-        rep.lumpSumContainer.items.forEach {
-            html += "<tr>" +
+                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Pauschale</th>" +
+                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Anzahl</th>" +
+                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Bemerkung</th>" +
+                    "</tr>"
+            rep.lumpSumContainer.items.forEach {
+                html += "<tr>" +
                         "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.item.value}</td>" +
                         "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.amount.value}</td>" +
                         "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.comment.value}</td>" +
-                    "</tr>"
+                        "</tr>"
+            }
+            html += "</table><hr>"
         }
-        html += "</table><hr>"
 
         // Material table
-        html += "<h2>Material</h2>" +
-                "<table style=\"border: 2px solid black;border-collapse: collapse;\">"
-        if(rep.materialContainer.isAnyMaterialUnitSet()) {
-            html += "<tr>" +
+        if(rep.materialContainer.items.size > 0) {
+            html += "<h2>Material</h2>" +
+                    "<table style=\"border: 2px solid black;border-collapse: collapse;\">"
+            if (rep.materialContainer.isAnyMaterialUnitSet()) {
+                html += "<tr>" +
                         "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Material</th>" +
                         "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Anzahl</th>" +
                         "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Einheit</th>" +
-                    "</tr>"
-            rep.materialContainer.items.forEach {
-                html += "<tr>" +
-                        "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.item.value}</td>" +
-                        "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.amount.value}</td>" +
-                        "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.unit.value}</td>" +
                         "</tr>"
-            }
-        } else {
-            html += "<tr>" +
-                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Material</th>" +
-                    "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Anzahl</th>" +
-                    "</tr>"
-            rep.materialContainer.items.forEach {
+                rep.materialContainer.items.forEach {
+                    html += "<tr>" +
+                            "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.item.value}</td>" +
+                            "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.amount.value}</td>" +
+                            "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.unit.value}</td>" +
+                            "</tr>"
+                }
+            } else {
                 html += "<tr>" +
-                        "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.item.value}</td>" +
-                        "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.amount.value}</td>" +
+                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Material</th>" +
+                        "<th style=\"padding: 15px;$fs;text-align:left;border: 2px solid black;border-collapse: collapse;\">Anzahl</th>" +
                         "</tr>"
+                rep.materialContainer.items.forEach {
+                    html += "<tr>" +
+                            "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.item.value}</td>" +
+                            "<td style=\"padding: 10px;$fs;border: 2px solid black;border-collapse: collapse;\"> ${it.amount.value}</td>" +
+                            "</tr>"
+                }
             }
+            html += "</table><hr>"
         }
-        html += "</table><hr>"
+
         if(rep.photoContainer.items.size != 0) {
             html += "<h2>Fotos</h2>"
             rep.photoContainer.items.forEach {
@@ -201,4 +210,3 @@ object HtmlReport {
         return html
     }
 }
-

--- a/app/src/main/java/com/stemaker/arbeitsbericht/helpers/PdfPreviewDialog.kt
+++ b/app/src/main/java/com/stemaker/arbeitsbericht/helpers/PdfPreviewDialog.kt
@@ -1,0 +1,156 @@
+package com.stemaker.arbeitsbericht.helpers
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.pdf.PdfRenderer
+import android.os.Bundle
+import android.os.ParcelFileDescriptor
+import android.util.Log
+import android.view.*
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.Toast
+import androidx.fragment.app.DialogFragment
+import com.stemaker.arbeitsbericht.R
+import java.io.File
+import kotlin.math.abs
+
+class PdfPreviewDialog(val file: File, val ctx: Context) : DialogFragment() {
+    private val fd: ParcelFileDescriptor? = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+    private val renderer: PdfRenderer? = fd?.let { PdfRenderer(it) }
+    private var currentPage = 0
+    private var bitmap: Bitmap? = null
+    private lateinit var imgV: ImageView
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val v = inflater.inflate(R.layout.fragment_pdf_preview_dialog, container, false)
+        val btnClose: View = v.findViewById(R.id.close_button)
+        btnClose.setOnClickListener {
+            renderer?.close()
+            dismiss()
+        }
+        val btnPrev: View = v.findViewById(R.id.prev_button)
+        btnPrev.setOnClickListener {
+            previousPage()
+        }
+        val btnNext: View = v.findViewById(R.id.next_button)
+        btnNext.setOnClickListener {
+            nextPage()
+        }
+        imgV = v.findViewById(R.id.pdf_preview_image_view)
+
+        if(renderer == null) {
+            val toast = Toast.makeText(ctx, R.string.pdf_viewer_fail, Toast.LENGTH_LONG)
+            toast.show()
+            dismiss()
+        } else {
+            renderPage(currentPage)
+            imgV.setOnTouchListener(object: OnSwipeTouchListener(ctx) {
+                override fun onSwipeLeft() {
+                    nextPage()
+                }
+                override fun onSwipeRight() {
+                    previousPage()
+                }
+            })
+        }
+        return v
+    }
+
+    private fun previousPage() {
+        currentPage--
+        if(currentPage < 0)
+            currentPage = 0
+        renderPage(currentPage)
+    }
+
+    private fun nextPage() {
+        renderer?.also {
+            currentPage++
+            if (currentPage >= renderer.pageCount)
+                currentPage = renderer.pageCount - 1
+            renderPage(currentPage)
+        }
+    }
+
+    private fun renderPage(page: Int) {
+        if (renderer != null) {
+            val page = renderer.openPage(page)
+            bitmap?.eraseColor(Color.WHITE)?:run {
+                bitmap = Bitmap.createBitmap(page.width, page.height, Bitmap.Config.ARGB_8888)
+            }
+            bitmap?.also {
+                page.render(it, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                imgV.setImageBitmap(it)
+            }
+            page.close()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val params = dialog!!.window!!.attributes!!
+        params.width = ViewGroup.LayoutParams.MATCH_PARENT
+        params.height = ViewGroup.LayoutParams.MATCH_PARENT
+        dialog!!.window!!.attributes = params
+    }
+
+    open class OnSwipeTouchListener(ctx: Context) : View.OnTouchListener {
+        private val gestureDetector: GestureDetector
+
+        companion object {
+            private const val SWIPE_THRESHOLD = 100
+            private const val SWIPE_VELOCITY_THRESHOLD = 100
+        }
+
+        init {
+            gestureDetector = GestureDetector(ctx, GestureListener())
+        }
+
+        override fun onTouch(v: View, event: MotionEvent): Boolean {
+            return gestureDetector.onTouchEvent(event)
+        }
+
+        private inner class GestureListener : GestureDetector.SimpleOnGestureListener() {
+
+
+            override fun onDown(e: MotionEvent): Boolean {
+                return true
+            }
+
+            override fun onFling(e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
+                var result = false
+                try {
+                    val diffY = e2.y - e1.y
+                    val diffX = e2.x - e1.x
+                    if (abs(diffX) > abs(diffY)) {
+                        if (abs(diffX) > SWIPE_THRESHOLD && abs(velocityX) > SWIPE_VELOCITY_THRESHOLD) {
+                            if (diffX > 0) {
+                                onSwipeRight()
+                            } else {
+                                onSwipeLeft()
+                            }
+                            result = true
+                        }
+                    } else if (abs(diffY) > SWIPE_THRESHOLD && abs(velocityY) > SWIPE_VELOCITY_THRESHOLD) {
+                        if (diffY > 0) {
+                            onSwipeBottom()
+                        } else {
+                            onSwipeTop()
+                        }
+                        result = true
+                    }
+                } catch (exception: Exception) {
+                    exception.printStackTrace()
+                }
+                return result
+            }
+        }
+
+        open fun onSwipeRight() {}
+        open fun onSwipeLeft() {}
+        open fun onSwipeTop() {}
+        open fun onSwipeBottom() {}
+    }
+}

--- a/app/src/main/java/com/stemaker/arbeitsbericht/output/ReportGenerator.kt
+++ b/app/src/main/java/com/stemaker/arbeitsbericht/output/ReportGenerator.kt
@@ -97,7 +97,7 @@ abstract class ReportGenerator(val activity: Activity, val report: ReportData, p
         return getHash(files) == report.lastStoreHash.toString() && report.lastStoreHash != 0
     }
 
-    suspend fun create(files: Array<File>) {
+    suspend fun create(files: Array<File>): Boolean {
         if(renderInUiThread) {
             var cont: Continuation<Boolean>? = null
             createDoc(files) {
@@ -109,6 +109,7 @@ abstract class ReportGenerator(val activity: Activity, val report: ReportData, p
                 cont = it
             }
             Log.d(TAG, "resume")
+            return true
         } else {
             val msg = Message()
             msg.what = MSG_CREATE
@@ -116,8 +117,7 @@ abstract class ReportGenerator(val activity: Activity, val report: ReportData, p
                 msg.obj = Create(files, it)
                 docHandler.sendMessage(msg)
             }
-            if (ret.success) return
-            throw(Exception(ret.error))
+            return ret.success
         }
     }
 

--- a/app/src/main/java/com/stemaker/arbeitsbericht/output/XlsxGenerator.kt
+++ b/app/src/main/java/com/stemaker/arbeitsbericht/output/XlsxGenerator.kt
@@ -483,99 +483,123 @@ class XlsxGenerator(activity: Activity, report: ReportData, progressBar: Progres
     }
 
     private fun setWorkTime(sheet: XSSFSheet, startRow: Int): Int {
-        val rown = startRow
-        val table = TableCoordinates(startRow+1, startRow+1+report.workTimeContainer.items.size, 0, 7)
-        // Headline
-        var row = sheet.createRow(rown)
-        row.createCell(0).also {
-            it.setCellStyle(styles[StyleTypes.HEAD2])
-            it.setCellValue("Arbeits- / Fahrzeiten und Fahrstrecken")
-        }
+        if(report.workTimeContainer.items.size > 0) {
+            val rown = startRow
+            val table = TableCoordinates(startRow + 1, startRow + 1 + report.workTimeContainer.items.size, 0, 7)
+            // Headline
+            var row = sheet.createRow(rown)
+            row.createCell(0).also {
+                it.setCellStyle(styles[StyleTypes.HEAD2])
+                it.setCellValue("Arbeits- / Fahrzeiten und Fahrstrecken")
+            }
 
-        row = sheet.createRow(rown+1)
-        fillTableHeads(row, arrayOf("Datum", "Mitarbeiter", "Arbeits-anfang", "Arbeits-ende", "Fahrzeit [h:m]", "Fahr-strecke [km]", "Pause [h:m]", "Arbeitszeit [h:m]"))
-        report.workTimeContainer.items.forEachIndexed { rowIdx, item ->
-            row = sheet.createRow(rown+2+rowIdx)
-            var employees = ""
-            for(e in item.employees) employees += "${e.value}\n"
-            val columns = arrayOf(calendarToDateString(item.date.value), employees, item.startTime.value, item.endTime.value, item.driveTime.value, item.distance.value.toString(), item.pauseDuration.value, item.workDuration.value)
-            columns.forEachIndexed { colIdx, e ->
-                row.createCell(colIdx).also {
-                    it.setCellStyle(selectTableStyle(table, startRow+2+rowIdx, colIdx))
-                    it.setCellValue(e)
+            row = sheet.createRow(rown + 1)
+            fillTableHeads(
+                row,
+                arrayOf("Datum", "Mitarbeiter", "Arbeits-anfang", "Arbeits-ende", "Fahrzeit [h:m]", "Fahr-strecke [km]", "Pause [h:m]", "Arbeitszeit [h:m]")
+            )
+            report.workTimeContainer.items.forEachIndexed { rowIdx, item ->
+                row = sheet.createRow(rown + 2 + rowIdx)
+                var employees = ""
+                for (e in item.employees) employees += "${e.value}\n"
+                val columns = arrayOf(
+                    calendarToDateString(item.date.value),
+                    employees,
+                    item.startTime.value,
+                    item.endTime.value,
+                    item.driveTime.value,
+                    item.distance.value.toString(),
+                    item.pauseDuration.value,
+                    item.workDuration.value
+                )
+                columns.forEachIndexed { colIdx, e ->
+                    row.createCell(colIdx).also {
+                        it.setCellStyle(selectTableStyle(table, startRow + 2 + rowIdx, colIdx))
+                        it.setCellValue(e)
+                    }
                 }
             }
-        }
-        return 2+report.workTimeContainer.items.size
+            return 2 + report.workTimeContainer.items.size
+        } else
+            return 0
     }
 
     private fun setWorkItem(sheet: XSSFSheet, startRow: Int): Int {
-        val rown = startRow
-        val table = TableCoordinates(startRow+1, startRow+1+report.workItemContainer.items.size, 0, 0)
-        // Headline
-        var row = sheet.createRow(rown)
-        row.createCell(0).also {
-            it.setCellStyle(styles[StyleTypes.HEAD2])
-            it.setCellValue("Durchgeführte Arbeiten")
-        }
-        row = sheet.createRow(rown+1)
-        fillTableHeads(row, arrayOf("Arbeit"))
-        report.workItemContainer.items.forEachIndexed { rowIdx, item ->
-            row = sheet.createRow(rown+2+rowIdx)
+        if(report.workItemContainer.items.size > 0) {
+            val rown = startRow
+            val table = TableCoordinates(startRow + 1, startRow + 1 + report.workItemContainer.items.size, 0, 0)
+            // Headline
+            var row = sheet.createRow(rown)
             row.createCell(0).also {
-                it.setCellStyle(selectTableStyle(table, startRow+2+rowIdx, 0))
-                it.setCellValue(item.item.value)
+                it.setCellStyle(styles[StyleTypes.HEAD2])
+                it.setCellValue("Durchgeführte Arbeiten")
             }
-        }
-        return 2+report.workItemContainer.items.size
+            row = sheet.createRow(rown + 1)
+            fillTableHeads(row, arrayOf("Arbeit"))
+            report.workItemContainer.items.forEachIndexed { rowIdx, item ->
+                row = sheet.createRow(rown + 2 + rowIdx)
+                row.createCell(0).also {
+                    it.setCellStyle(selectTableStyle(table, startRow + 2 + rowIdx, 0))
+                    it.setCellValue(item.item.value)
+                }
+            }
+            return 2 + report.workItemContainer.items.size
+        } else
+            return 0
     }
 
     private fun setLumpSum(sheet: XSSFSheet, startRow: Int): Int {
-        val rown = startRow
-        val table = TableCoordinates(startRow+1, startRow+1+report.lumpSumContainer.items.size, 0, 2)
-        // Headline
-        var row = sheet.createRow(rown)
-        row.createCell(0).also {
-            it.setCellStyle(styles[StyleTypes.HEAD2])
-            it.setCellValue("Pauschalen")
-        }
-        row = sheet.createRow(rown+1)
-        fillTableHeads(row, arrayOf("Pauschale", "Bemerkung", "Anzahl"))
-        report.lumpSumContainer.items.forEachIndexed { rowIdx, item ->
-            row = sheet.createRow(rown+2+rowIdx)
-            val columns = arrayOf(item.item.value, item.comment.value, item.amount.value.toString())
-            columns.forEachIndexed { colIdx, e ->
-                row.createCell(colIdx).also {
-                    it.setCellStyle(selectTableStyle(table, startRow+2+rowIdx, colIdx))
-                    it.setCellValue(e)
+        if(report.lumpSumContainer.items.size > 0) {
+            val rown = startRow
+            val table = TableCoordinates(startRow + 1, startRow + 1 + report.lumpSumContainer.items.size, 0, 2)
+            // Headline
+            var row = sheet.createRow(rown)
+            row.createCell(0).also {
+                it.setCellStyle(styles[StyleTypes.HEAD2])
+                it.setCellValue("Pauschalen")
+            }
+            row = sheet.createRow(rown + 1)
+            fillTableHeads(row, arrayOf("Pauschale", "Bemerkung", "Anzahl"))
+            report.lumpSumContainer.items.forEachIndexed { rowIdx, item ->
+                row = sheet.createRow(rown + 2 + rowIdx)
+                val columns = arrayOf(item.item.value, item.comment.value, item.amount.value.toString())
+                columns.forEachIndexed { colIdx, e ->
+                    row.createCell(colIdx).also {
+                        it.setCellStyle(selectTableStyle(table, startRow + 2 + rowIdx, colIdx))
+                        it.setCellValue(e)
+                    }
                 }
             }
-        }
-        return 2+report.lumpSumContainer.items.size
+            return 2 + report.lumpSumContainer.items.size
+        } else
+            return 0
     }
 
     private fun setMaterial(sheet: XSSFSheet, startRow: Int): Int {
-        val rown = startRow
-        val table = TableCoordinates(startRow+1, startRow+1+report.materialContainer.items.size, 0, 1)
-        // Headline
-        var row = sheet.createRow(rown)
-        row.createCell(0).also {
-            it.setCellStyle(styles[StyleTypes.HEAD2])
-            it.setCellValue("Material")
-        }
-        row = sheet.createRow(rown+1)
-        fillTableHeads(row, arrayOf("Material", "Anzahl"))
-        report.materialContainer.items.forEachIndexed { rowIdx, item ->
-            row = sheet.createRow(rown+2+rowIdx)
-            val columns = arrayOf(item.item.value, item.amount.value.toString())
-            columns.forEachIndexed { colIdx, e ->
-                row.createCell(colIdx).also {
-                    it.setCellStyle(selectTableStyle(table, startRow+2+rowIdx, colIdx))
-                    it.setCellValue(e)
+        if(report.materialContainer.items.size > 0) {
+            val rown = startRow
+            val table = TableCoordinates(startRow + 1, startRow + 1 + report.materialContainer.items.size, 0, 1)
+            // Headline
+            var row = sheet.createRow(rown)
+            row.createCell(0).also {
+                it.setCellStyle(styles[StyleTypes.HEAD2])
+                it.setCellValue("Material")
+            }
+            row = sheet.createRow(rown + 1)
+            fillTableHeads(row, arrayOf("Material", "Anzahl"))
+            report.materialContainer.items.forEachIndexed { rowIdx, item ->
+                row = sheet.createRow(rown + 2 + rowIdx)
+                val columns = arrayOf(item.item.value, item.amount.value.toString())
+                columns.forEachIndexed { colIdx, e ->
+                    row.createCell(colIdx).also {
+                        it.setCellStyle(selectTableStyle(table, startRow + 2 + rowIdx, colIdx))
+                        it.setCellValue(e)
+                    }
                 }
             }
-        }
-        return 2+report.materialContainer.items.size
+            return 2 + report.materialContainer.items.size
+        } else
+            return 0
     }
 
     private fun setPhoto(wb: XSSFWorkbook) {

--- a/app/src/main/res/drawable/ic_baseline_chevron_left_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_chevron_left_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15.41,7.41L14,6l-6,6 6,6 1.41,-1.41L10.83,12z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_chevron_right_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_chevron_right_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M10,6L8.59,7.41 13.17,12l-4.58,4.59L10,18l6,-6z"/>
+</vector>

--- a/app/src/main/res/layout/config_pdf.xml
+++ b/app/src/main/res/layout/config_pdf.xml
@@ -39,11 +39,20 @@
                 app:layout_constraintTop_toBottomOf="@id/pdf_use_logo"
                 app:layout_constraintLeft_toLeftOf="parent"
                 android:text="@string/use_footer"/>
+        <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/pdf_use_internal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:layout_marginBottom="20dp"
+                app:layout_constraintTop_toBottomOf="@id/pdf_use_footer"
+                app:layout_constraintLeft_toLeftOf="parent"
+                android:text="@string/use_internal_pdf"/>
         <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/fontsize_text_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:layout_constraintTop_toBottomOf="@id/pdf_use_footer"
+                app:layout_constraintTop_toBottomOf="@id/pdf_use_internal"
                 app:layout_constraintLeft_toLeftOf="parent" >
             <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/fontsize_text"

--- a/app/src/main/res/layout/fragment_pdf_preview_dialog.xml
+++ b/app/src/main/res/layout/fragment_pdf_preview_dialog.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
+    <ImageView
+            android:id="@+id/pdf_preview_image_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent">
+    </ImageView>
+    <ImageButton
+            android:id="@+id/prev_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_baseline_chevron_left_24"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent">
+    </ImageButton>
+    <ImageButton
+            android:id="@+id/next_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_baseline_chevron_right_24"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintRight_toRightOf="parent">
+    </ImageButton>
+    <ImageButton
+            android:id="@+id/close_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_clear_black_24dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintRight_toRightOf="parent">
+    </ImageButton>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="del_signature">Sind sie sich sicher, dass sie die Unterschrift löschen wollen?</string>
     <string name="overwrite_confirmation">Der Bericht exisitiert bereits als PDF, soll er überschrieben werden?</string>
     <string name="send_fail">Senden fehlgeschlagen!</string>
+    <string name="pdf_viewer_fail">Konnte PDF Renderer nicht generieren</string>
     <string name="sharing">Bericht teilen ...</string>
     <string name="ok">OK</string>
     <string name="cancel">Abbrechen</string>
@@ -96,6 +97,7 @@
     <string name="fontsize">Schriftgröße</string>
     <string name="use_logo">Logo verwenden</string>
     <string name="use_footer">Fusszeile verwenden</string>
+    <string name="use_internal_pdf">Eigene PDF Vorschau</string>
     <string name="logowidth">Logobreite [mm]</string>
     <string name="footerwidth">Fusszeilenbreite [mm]</string>
 


### PR DESCRIPTION
- Support for an inline PDF viewer used by default. Option to use an external viewer
- In PDF and XLSX reports sections without entries are left out. ODF is unchanged
- Bug fixes based on crash reports in play console. I was not able to reproduce any of those.